### PR TITLE
Unify streamer settings pages, add 'your city' settings

### DIFF
--- a/app/settings/city.tsx
+++ b/app/settings/city.tsx
@@ -1,0 +1,47 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Stack } from "expo-router";
+import { getItem } from "expo-secure-store";
+import { useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "react-native-paper";
+
+const CitySettingsPage = () => {
+  const { t } = useLingui();
+
+  const [userCity, setCityState] = useState(
+    getItem("userCityIdAndName"),
+  );
+
+  return (
+    <View style={styles.container}>
+      {/* <Stack.SearchBar placeholder={t`Search your city...`} /> */}
+      <View style={[styles.container, styles.centredContainer]}>
+        <Text style={styles.copy} variant="bodyMedium">
+          {userCity ?
+            <Trans>
+              Your city is currently set to {userCity}.
+            </Trans> : <Trans>
+              Select your city to see gigs in your area on the homepage.
+            </Trans>}
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centredContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  copy: {
+    marginHorizontal: 12,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+});
+
+export default CitySettingsPage;

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -38,28 +38,38 @@ const SettingsPage = () => {
     !!getItem(TIDAL_BEARER_TOKEN_STORAGE_KEY),
   );
 
+  const [userCity, setCityState] = useState(getItem("userCityIdAndName"));
+
   const settings: SettingItem[] = [
+    {
+      label: t`Connected streaming service`,
+      value: spotifyHasSetup ? "Spotify" : appleMusicHasSetup ? "Apple Music" : t`Set up`,
+      onPress: console.log, // todo: move spotify/apple music / tidal to one page
+    },
+    // deprecated
     {
       label: "Spotify",
       value: spotifyHasSetup ? t`Connected` : t`Set up`,
       onPress: () => router.navigate("/settings/spotify"),
     },
+    // deprecated
     {
       label: "Apple Music",
       value: appleMusicHasSetup ? t`Connected` : t`Set up`,
       onPress: () => router.navigate("/settings/appleMusic"),
     },
-    // {
-    //   label: "TIDAL",
-    //   value: tidalHasSetup ? t`Connected` : t`Set up`,
-    //   onPress: () => router.navigate("/settings/tidal"),
-    // },
+    {
+      label: t`Your city`,
+      value: userCity ?? t`Set up`,
+      onPress: () => router.navigate("/settings/city"),
+    }
   ];
 
   useFocusEffect(() => {
     setSpotifySetupState(!!getItem(SPOTIFY_BEARER_TOKEN_STORAGE_KEY));
     setAppleMusicSetupState(!!getItem(APPLE_MUSIC_USER_TOKEN_STORAGE_KEY));
-    setTidalSetupState(!!getItem(TIDAL_BEARER_TOKEN_STORAGE_KEY))
+    setTidalSetupState(!!getItem(TIDAL_BEARER_TOKEN_STORAGE_KEY));
+    setCityState(getItem("userCityIdAndName"));
   });
 
   // @TODO: when there's >1 category of settings, use a SectionList instead


### PR DESCRIPTION
Plan outline

* Move all streamer settings into one page - allow one streamer to be configured at a time
* Add 'your city' settings option - this will be used in a later feature to localise the homepage (limit top10 setlist query to city id)
* Add new state key: this will be the city ID and friendly name separated by a pipe
* No auto-locate because of stinky permissions